### PR TITLE
Fixed "'swap' is not defined in this scope".

### DIFF
--- a/combinational/rand_cliff/rand_cliff_10_AG.qasm
+++ b/combinational/rand_cliff/rand_cliff_10_AG.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[10];
 x q[9];
 z q[9];

--- a/combinational/rand_cliff/rand_cliff_10_GD.qasm
+++ b/combinational/rand_cliff/rand_cliff_10_GD.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[10];
 s q[0];
 h q[0];

--- a/combinational/rand_cliff/rand_cliff_11_AG.qasm
+++ b/combinational/rand_cliff/rand_cliff_11_AG.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[11];
 x q[10];
 z q[10];

--- a/combinational/rand_cliff/rand_cliff_11_GD.qasm
+++ b/combinational/rand_cliff/rand_cliff_11_GD.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[11];
 h q[1];
 s q[2];

--- a/combinational/rand_cliff/rand_cliff_12_AG.qasm
+++ b/combinational/rand_cliff/rand_cliff_12_AG.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[12];
 x q[11];
 x q[10];

--- a/combinational/rand_cliff/rand_cliff_12_GD.qasm
+++ b/combinational/rand_cliff/rand_cliff_12_GD.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[12];
 s q[0];
 s q[1];

--- a/combinational/rand_cliff/rand_cliff_13_AG.qasm
+++ b/combinational/rand_cliff/rand_cliff_13_AG.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[13];
 x q[10];
 z q[10];

--- a/combinational/rand_cliff/rand_cliff_13_GD.qasm
+++ b/combinational/rand_cliff/rand_cliff_13_GD.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[13];
 s q[1];
 h q[1];

--- a/combinational/rand_cliff/rand_cliff_14_AG.qasm
+++ b/combinational/rand_cliff/rand_cliff_14_AG.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[14];
 x q[12];
 z q[11];

--- a/combinational/rand_cliff/rand_cliff_14_GD.qasm
+++ b/combinational/rand_cliff/rand_cliff_14_GD.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[14];
 h q[0];
 s q[1];

--- a/combinational/rand_cliff/rand_cliff_15_AG.qasm
+++ b/combinational/rand_cliff/rand_cliff_15_AG.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[15];
 x q[12];
 z q[12];

--- a/combinational/rand_cliff/rand_cliff_15_GD.qasm
+++ b/combinational/rand_cliff/rand_cliff_15_GD.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[15];
 h q[1];
 s q[3];

--- a/combinational/rand_cliff/rand_cliff_16_AG.qasm
+++ b/combinational/rand_cliff/rand_cliff_16_AG.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[16];
 x q[15];
 z q[15];

--- a/combinational/rand_cliff/rand_cliff_16_GD.qasm
+++ b/combinational/rand_cliff/rand_cliff_16_GD.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[16];
 s q[0];
 h q[0];

--- a/combinational/rand_cliff/rand_cliff_17_AG.qasm
+++ b/combinational/rand_cliff/rand_cliff_17_AG.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[17];
 x q[14];
 z q[13];

--- a/combinational/rand_cliff/rand_cliff_17_GD.qasm
+++ b/combinational/rand_cliff/rand_cliff_17_GD.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[17];
 h q[0];
 h q[1];

--- a/combinational/rand_cliff/rand_cliff_18_AG.qasm
+++ b/combinational/rand_cliff/rand_cliff_18_AG.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[18];
 x q[17];
 z q[17];

--- a/combinational/rand_cliff/rand_cliff_18_GD.qasm
+++ b/combinational/rand_cliff/rand_cliff_18_GD.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[18];
 h q[2];
 s q[3];

--- a/combinational/rand_cliff/rand_cliff_19_AG.qasm
+++ b/combinational/rand_cliff/rand_cliff_19_AG.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[19];
 z q[17];
 x q[16];

--- a/combinational/rand_cliff/rand_cliff_19_GD.qasm
+++ b/combinational/rand_cliff/rand_cliff_19_GD.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[19];
 s q[0];
 h q[0];

--- a/combinational/rand_cliff/rand_cliff_2_AG.qasm
+++ b/combinational/rand_cliff/rand_cliff_2_AG.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[2];
 x q[0];
 z q[0];

--- a/combinational/rand_cliff/rand_cliff_2_GD.qasm
+++ b/combinational/rand_cliff/rand_cliff_2_GD.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[2];
 s q[0];
 h q[0];

--- a/combinational/rand_cliff/rand_cliff_4_AG.qasm
+++ b/combinational/rand_cliff/rand_cliff_4_AG.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[4];
 x q[3];
 z q[3];

--- a/combinational/rand_cliff/rand_cliff_4_GD.qasm
+++ b/combinational/rand_cliff/rand_cliff_4_GD.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[4];
 h q[0];
 h q[2];

--- a/combinational/rand_cliff/rand_cliff_5_AG.qasm
+++ b/combinational/rand_cliff/rand_cliff_5_AG.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[5];
 x q[4];
 x q[2];

--- a/combinational/rand_cliff/rand_cliff_5_GD.qasm
+++ b/combinational/rand_cliff/rand_cliff_5_GD.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[5];
 s q[0];
 h q[0];

--- a/combinational/rand_cliff/rand_cliff_6_AG.qasm
+++ b/combinational/rand_cliff/rand_cliff_6_AG.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[6];
 x q[4];
 z q[4];

--- a/combinational/rand_cliff/rand_cliff_6_GD.qasm
+++ b/combinational/rand_cliff/rand_cliff_6_GD.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[6];
 s q[0];
 h q[0];

--- a/combinational/rand_cliff/rand_cliff_7_AG.qasm
+++ b/combinational/rand_cliff/rand_cliff_7_AG.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[7];
 z q[5];
 z q[4];

--- a/combinational/rand_cliff/rand_cliff_7_GD.qasm
+++ b/combinational/rand_cliff/rand_cliff_7_GD.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[7];
 s q[2];
 h q[2];

--- a/combinational/rand_cliff/rand_cliff_8_AG.qasm
+++ b/combinational/rand_cliff/rand_cliff_8_AG.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[8];
 z q[7];
 x q[6];

--- a/combinational/rand_cliff/rand_cliff_8_GD.qasm
+++ b/combinational/rand_cliff/rand_cliff_8_GD.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[8];
 s q[0];
 h q[0];

--- a/combinational/rand_cliff/rand_cliff_9_AG.qasm
+++ b/combinational/rand_cliff/rand_cliff_9_AG.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[9];
 x q[8];
 x q[7];

--- a/combinational/rand_cliff/rand_cliff_9_GD.qasm
+++ b/combinational/rand_cliff/rand_cliff_9_GD.qasm
@@ -1,5 +1,5 @@
-OPENQASM 2.0;
-include "qelib1.inc";
+OPENQASM 3.0;
+include "stdgates.inc";
 qreg q[9];
 s q[0];
 s q[1];


### PR DESCRIPTION
I truly failed to understand the issue that this PR fixes.  To the best of my knowledge, [the `swap` gate is defined in the `qelib1.inc`](https://github.com/Qiskit/qiskit/blob/main/qiskit/qasm/libs/qelib1.inc#L60-L61).  However, `qiskit.qasm2.load(...)` keeps reporting "'swap' is not defined in this scope" for all these circuits.

My system:
```
$ python -V
Python 3.13.1

$ pip freeze | grep qiskit
qiskit==1.3.2
qiskit-aer==0.16.0
qiskit-algorithms==0.3.1
qiskit-ibm-runtime==0.34.0
qiskit-optimization==0.6.1
qiskit-qasm3-import==0.5.1
qiskit_utils==1.2.1

$ pip3 freeze | grep qasm
openqasm3==1.0.0
qiskit-qasm3-import==0.5.1
```